### PR TITLE
Fix SVG tags like clipPath

### DIFF
--- a/converter.ts
+++ b/converter.ts
@@ -26,7 +26,7 @@ export const htmlToVanCode = (html: string, {
   indent = 2,
   spacing = false,
   skipEmptyText = false,
-  htmlTagPred = s => s.toLowerCase() === s,
+  htmlTagPred = s => s[0].toUpperCase() !== s[0],
 }: HtmlToVanCodeOptions = {}) => {
   const attrsToVanCode = (attrs: Record<string, string>, children: readonly Dom[]) => {
     const space = spacing ? " " : ""

--- a/dist/converter.js
+++ b/dist/converter.js
@@ -5,7 +5,7 @@ const quoteIfNeeded = (key) => /^[a-zA-Z_][a-zA-Z_0-9]+$/.test(key) ? key : `"${
 const filterDoms = (doms, skipEmptyText) => doms.filter(c => c.type === "tag" && c.name !== dummy ||
     c.type === "text" && (!skipEmptyText || /\S/.test(c.data)) ||
     c.type === "script");
-export const htmlToVanCode = (html, { indent = 2, spacing = false, skipEmptyText = false, htmlTagPred = s => s.toLowerCase() === s, } = {}) => {
+export const htmlToVanCode = (html, { indent = 2, spacing = false, skipEmptyText = false, htmlTagPred = s => s[0].toUpperCase() !== s[0], } = {}) => {
     const attrsToVanCode = (attrs, children) => {
         const space = spacing ? " " : "";
         return Object.keys(attrs).length === 0 ? "" :


### PR DESCRIPTION
As described in #4 tags like `clipPath` should not be included in `components` exports array but in the `tags` array.

We must assume that component names start with a capital letter not that it contains one.